### PR TITLE
Uses env hooks instead of compiled paths.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,9 @@ endif()
 # Export
 ##############################################################################
 
+ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/env-hooks/${PROJECT_NAME}.dsv.in")
+ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/env-hooks/${PROJECT_NAME}.sh.in")
+
 ament_export_dependencies(ament_cmake)
 ament_export_targets(${PROJECT_NAME}-targets HAS_LIBRARY_TARGET)
 

--- a/env-hooks/maliput_viz.dsv.in
+++ b/env-hooks/maliput_viz.dsv.in
@@ -1,0 +1,2 @@
+prepend-non-duplicate;MALIPUT_VIZ_RESOURCE_ROOT;share/@PROJECT_NAME@
+prepend-non-duplicate;MALIPUT_VIZ_GUI_PLUGINS;lib/gui_plugins

--- a/env-hooks/maliput_viz.sh.in
+++ b/env-hooks/maliput_viz.sh.in
@@ -1,0 +1,2 @@
+ament_prepend_unique_value MALIPUT_VIZ_RESOURCE_ROOT "$AMENT_CURRENT_PREFIX/share/@PROJECT_NAME@"
+ament_prepend_unique_value MALIPUT_VIZ_GUI_PLUGINS "$AMENT_CURRENT_PREFIX/lib/gui_plugins"

--- a/src/maliput_viz/application/CMakeLists.txt
+++ b/src/maliput_viz/application/CMakeLists.txt
@@ -9,12 +9,6 @@ target_link_libraries(maliput_viz
   ${Qt5Widgets_LIBRARIES}
 )
 
-target_compile_definitions(maliput_viz
-  PRIVATE
-    MALIPUT_VIZ_PLUGIN_PATH="${CMAKE_INSTALL_PREFIX}/lib/gui_plugins"
-    MALIPUT_VIZ_INITIAL_CONFIG_PATH="${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}/maliput_viz/layouts"
-)
-
 install(
   TARGETS maliput_viz
   EXPORT ${PROJECT_NAME}-targets

--- a/src/maliput_viz/config/CMakeLists.txt
+++ b/src/maliput_viz/config/CMakeLists.txt
@@ -3,5 +3,5 @@ install(
   FILES
     maliput_viz_layout.config
   DESTINATION
-    ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}/maliput_viz/layouts
+    share/${PROJECT_NAME}/layouts
 )

--- a/src/maliput_viz/plugins/maliput_backend_selection.cc
+++ b/src/maliput_viz/plugins/maliput_backend_selection.cc
@@ -141,7 +141,6 @@ MaliputBackendSelection::MaliputBackendSelection(QObject* parent) : QObject(pare
 }
 
 void MaliputBackendSelection::OnBackendSelected(const QString& _backendName) {
-  std::cout << "backend selected: " << _backendName.toStdString() << std::endl;
   // Clears the table model.
   parameterTableModel->ClearParameters();
 

--- a/src/maliput_viz/plugins/traffic_light_manager.cc
+++ b/src/maliput_viz/plugins/traffic_light_manager.cc
@@ -180,9 +180,9 @@ void TrafficLightManager::CreateRoundBulbMeshInManager() {
 }
 
 void TrafficLightManager::CreateArrowBulbMeshInManager() {
-  const std::list<std::string> paths = ignition::common::SystemPaths::PathsFromEnv("DELPHYNE_GUI_RESOURCE_ROOT");
+  const std::list<std::string> paths = ignition::common::SystemPaths::PathsFromEnv("MALIPUT_VIZ_RESOURCE_ROOT");
   MALIPUT_VALIDATE(!paths.empty(),
-                   "DELPHYNE_RESOURCE_ROOT environment "
+                   "MALIPUT_VIZ_RESOURCE_ROOT environment "
                    "variable is not set");
   const std::vector<std::string> resource_paths(paths.begin(), paths.end());
   arrowName = ignition::common::SystemPaths::LocateLocalFile(kArrowBulbOBJFilePath, resource_paths);

--- a/src/maliput_viz/resources/CMakeLists.txt
+++ b/src/maliput_viz/resources/CMakeLists.txt
@@ -3,5 +3,5 @@ install(
     arrow_bulb.obj
     arrow_bulb.mtl
   DESTINATION
-    ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}/maliput_viz/resources
+    share/${PROJECT_NAME}/resources
 )


### PR DESCRIPTION
# 🦟 Bug fix

Closes #9

## Summary
 - Use env hooks instead of compiled paths
 - Fixes installation path for some resources

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
