### PR TITLE
Fills edition boxes when a parameter is clicked.

### DIFF
--- a/src/maliput_viz/plugins/MaliputBackendConfigurationArea.qml
+++ b/src/maliput_viz/plugins/MaliputBackendConfigurationArea.qml
@@ -94,6 +94,7 @@ GridLayout {
   TableView {
     id: parametersTable
     Layout.fillWidth: true
+    selectionMode: 1 /* Single Selection */
     model: parameterTableModel
     TableViewColumn {
         role: "parameter"
@@ -104,6 +105,11 @@ GridLayout {
         role: "value"
         title: "Value"
         width: parametersTable.width * 0.4
+    }
+    onClicked: {
+      console.log("Clicked on row: ", row);
+      addKeyTextField.text = parameterTableModel.GetData(row, 101 /* parameter */);
+      addValueTextField.text = parameterTableModel.GetData(row, 102 /* value */);
     }
     itemDelegate: Item {
       Text {

--- a/src/maliput_viz/plugins/maliput_backend_selection.cc
+++ b/src/maliput_viz/plugins/maliput_backend_selection.cc
@@ -69,7 +69,7 @@ int ParameterTableModel::columnCount(const QModelIndex& parent) const { return r
 QVariant ParameterTableModel::data(const QModelIndex& index, int role) const {
   QString data;
   const int row = index.row();
-  return role == kParameterRole ? parameterList[row].parameterName : parameterList[row].parameterValue;
+  return GetData(row, role);
 }
 
 QHash<int, QByteArray> ParameterTableModel::roleNames() const {
@@ -77,6 +77,10 @@ QHash<int, QByteArray> ParameterTableModel::roleNames() const {
       {kParameterRole, "parameter"},
       {kValueRole, "value"},
   };
+}
+
+QString ParameterTableModel::GetData(int row, int role) const {
+  return role == kParameterRole ? parameterList[row].parameterName : parameterList[row].parameterValue;
 }
 
 std::map<std::string, std::string> ParameterTableModel::GetMapFromParameters() const {

--- a/src/maliput_viz/plugins/maliput_backend_selection.hh
+++ b/src/maliput_viz/plugins/maliput_backend_selection.hh
@@ -74,6 +74,9 @@ class ParameterTableModel : public QAbstractTableModel {
   /// Removes all parameters from the table.
   Q_INVOKABLE void ClearParameters();
 
+  /// Get data from a row.
+  Q_INVOKABLE QString GetData(int row, int role) const;
+
  protected:
   /// Documentation inherited
   Q_INVOKABLE int rowCount(const QModelIndex& parent = QModelIndex()) const override;


### PR DESCRIPTION
Signed-off-by: Franco Cipollone <franco.c@ekumenlabs.com>

# 🎉 New feature

Closes #16 

## Summary

Makes it easier to edit parameters.


https://user-images.githubusercontent.com/53065142/206482162-f7c6c0dd-082b-45fd-8405-f3aec8c3a902.mp4



## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
