### PR TITLE
Adds command line support for the maliput viz app.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(ament_cmake REQUIRED)
 
 find_package(ignition-gui3 REQUIRED)
 find_package(maliput REQUIRED)
+find_package(yaml-cpp REQUIRED)
 
 ##############################################################################
 # Project Configuration

--- a/package.xml
+++ b/package.xml
@@ -11,6 +11,7 @@
   <doc_depend>ament_cmake_doxygen</doc_depend>
 
   <depend>maliput</depend>
+  <depend>yaml-cpp</depend>
   <build_depend>ignition-gui3</build_depend>
 
   <test_depend>ament_cmake_clang_format</test_depend>

--- a/src/maliput_viz/CMakeLists.txt
+++ b/src/maliput_viz/CMakeLists.txt
@@ -1,4 +1,6 @@
 add_subdirectory(application)
 add_subdirectory(config)
+add_subdirectory(flags)
 add_subdirectory(plugins)
 add_subdirectory(resources)
+add_subdirectory(tools)

--- a/src/maliput_viz/application/CMakeLists.txt
+++ b/src/maliput_viz/application/CMakeLists.txt
@@ -5,8 +5,14 @@ add_executable(maliput_viz
 target_link_libraries(maliput_viz
   ignition-common3::ignition-common3
   ignition-gui3::ignition-gui3
+  maliput_viz::flags
   ${Qt5Core_LIBRARIES}
   ${Qt5Widgets_LIBRARIES}
+)
+
+target_include_directories(maliput_viz
+  PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
 )
 
 install(

--- a/src/maliput_viz/application/maliput_viz.cc
+++ b/src/maliput_viz/application/maliput_viz.cc
@@ -40,6 +40,8 @@
 #include <ignition/gui/qt.h>
 #endif
 
+#include "maliput_viz/flags/gflags.h"
+
 namespace maliput {
 namespace viz {
 namespace {
@@ -76,7 +78,10 @@ std::string GetMaliputVizConfigFile() {
 
 /////////////////////////////////////////////////
 int Main(int argc, char** argv) {
-  ignition::common::Console::SetVerbosity(3);
+  flags::SetUsageMessage();
+  flags::ParseCommandLineFlags(argc, argv, true);
+
+  ignition::common::Console::SetVerbosity(FLAGS_verbosity);
   ignmsg << kVersionStr << std::endl;
 
   // Initialize app

--- a/src/maliput_viz/application/maliput_viz.cc
+++ b/src/maliput_viz/application/maliput_viz.cc
@@ -81,7 +81,7 @@ int Main(int argc, char** argv) {
   flags::SetUsageMessage();
   flags::ParseCommandLineFlags(argc, argv, true);
 
-  ignition::common::Console::SetVerbosity(FLAGS_verbosity);
+  ignition::common::Console::SetVerbosity(flags::GetVerbosity());
   ignmsg << kVersionStr << std::endl;
 
   // Initialize app

--- a/src/maliput_viz/flags/CMakeLists.txt
+++ b/src/maliput_viz/flags/CMakeLists.txt
@@ -1,0 +1,27 @@
+add_library(flags
+  gflags.cc
+)
+
+add_library(maliput_viz::flags ALIAS flags)
+set_target_properties(flags
+  PROPERTIES
+    OUTPUT_NAME maliput_viz_flags
+)
+
+target_link_libraries(flags
+  gflags
+  maliput::common
+)
+
+target_include_directories(flags
+  PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
+)
+
+install(
+  TARGETS flags
+  EXPORT ${PROJECT_NAME}-targets
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+)

--- a/src/maliput_viz/flags/gflags.cc
+++ b/src/maliput_viz/flags/gflags.cc
@@ -1,0 +1,109 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2022, Woven Planet.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "maliput_viz/flags/gflags.h"
+
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#include <maliput/common/filesystem.h>
+
+// Gflags
+DEFINE_int32(verbosity, 3, "Verbosity is set within a range between [0-4]");
+DEFINE_string(yaml_file_path, "", "Path to the configuration YAML file");
+
+// Validators
+static bool ValidateVerbosity(const char* flagname, int32_t value) { return value >= 0 && value <= 4; }
+static bool ValidateConfigFilePath(const char* flagname, const std::string& value) {
+  if (!value.empty()) {
+    maliput::common::Path path{value};
+    if (!path.exists() || !path.is_file()) {
+      std::cout << "Please verify that '" << value << "' is a valid file path." << std::endl;
+      return false;
+    }
+  }
+  return true;
+}
+
+DEFINE_validator(verbosity, &ValidateVerbosity);
+DEFINE_validator(yaml_file_path, &ValidateConfigFilePath);
+
+namespace maliput {
+namespace viz {
+namespace flags {
+namespace {
+
+// Returns a string with the usage message.
+std::string GetUsageMessage() {
+  std::stringstream ss;
+  ss << "Application for maliput road network visualization" << std::endl << std::endl;
+  ss << "  maliput_viz [--<flag_1>] [--<flag_2>] .. [--<flag_n>] " << std::endl << std::endl;
+  ss << " * Summary: " << std::endl;
+  ss << "    This application offers a visualizer for the maliput road networks " << std::endl;
+  ss << "    It provides a GUI for interactively select a maliput backend and load the road network" << std::endl;
+  ss << "    passing the correspondent parameters. " << std::endl;
+  ss << "    In addition, a YAML configuration file could be passed via command line for setting up the visualizer "
+        "beforehand."
+     << std::endl
+     << std::endl;
+  ss << " * Examples of use: " << std::endl;
+  ss << "    1. Running the visualizer: " << std::endl;
+  ss << "       $ maliput_viz" << std::endl;
+  ss << "    2. Running the visualizer with a higher verbosity level: " << std::endl;
+  ss << "       $ maliput_viz --verbosity=4" << std::endl;
+  ss << "    3. Running the visualizer with a configuration file: " << std::endl;
+  ss << "       $ maliput_viz --yaml_file_path=<path-to-yaml-file> " << std::endl << std::endl;
+  ss << " * YAML file configuration: " << std::endl;
+  ss << "    The --yaml_file_path flag expects a valid path to a YAML file." << std::endl;
+  ss << "    The YAML file should contain the configuration for loading the road network." << std::endl;
+  ss << "    The structure of the YAML file should be: " << std::endl;
+  ss << "     |  maliput_viz:" << std::endl;
+  ss << "     |    maliput_backend: <backend_name> " << std::endl;
+  ss << "     |    parameters: " << std::endl;
+  ss << "     |       <key_1>: <value_1> " << std::endl;
+  ss << "     |       <key_2>: <value_2> " << std::endl;
+  ss << "     |       ...  " << std::endl;
+  ss << "     |       <key_N>: <value_N> " << std::endl << std::endl;
+
+  return ss.str();
+}
+
+}  // namespace
+
+void ParseCommandLineFlags(int argc, char** argv, bool remove_flags) {
+  gflags::ParseCommandLineFlags(&argc, &argv, remove_flags);
+}
+
+void SetUsageMessage() { gflags::SetUsageMessage(GetUsageMessage()); }
+
+}  // namespace flags
+}  // namespace viz
+}  // namespace maliput

--- a/src/maliput_viz/flags/gflags.cc
+++ b/src/maliput_viz/flags/gflags.cc
@@ -27,14 +27,13 @@
 // CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 #include "maliput_viz/flags/gflags.h"
 
-#include <iostream>
-#include <sstream>
 #include <string>
 
+#include <gflags/gflags.h>
 #include <maliput/common/filesystem.h>
+#include <maliput/common/logger.h>
 
 // Gflags
 DEFINE_int32(verbosity, 3, "Verbosity is set within a range between [0-4]");
@@ -46,7 +45,7 @@ static bool ValidateConfigFilePath(const char* flagname, const std::string& valu
   if (!value.empty()) {
     maliput::common::Path path{value};
     if (!path.exists() || !path.is_file()) {
-      std::cout << "Please verify that '" << value << "' is a valid file path." << std::endl;
+      maliput::log()->error("Please verify that '{}' is a valid file path.", value);
       return false;
     }
   }
@@ -61,40 +60,37 @@ namespace viz {
 namespace flags {
 namespace {
 
-// Returns a string with the usage message.
-std::string GetUsageMessage() {
-  std::stringstream ss;
-  ss << "Application for maliput road network visualization" << std::endl << std::endl;
-  ss << "  maliput_viz [--<flag_1>] [--<flag_2>] .. [--<flag_n>] " << std::endl << std::endl;
-  ss << " * Summary: " << std::endl;
-  ss << "    This application offers a visualizer for the maliput road networks " << std::endl;
-  ss << "    It provides a GUI for interactively select a maliput backend and load the road network" << std::endl;
-  ss << "    passing the correspondent parameters. " << std::endl;
-  ss << "    In addition, a YAML configuration file could be passed via command line for setting up the visualizer "
-        "beforehand."
-     << std::endl
-     << std::endl;
-  ss << " * Examples of use: " << std::endl;
-  ss << "    1. Running the visualizer: " << std::endl;
-  ss << "       $ maliput_viz" << std::endl;
-  ss << "    2. Running the visualizer with a higher verbosity level: " << std::endl;
-  ss << "       $ maliput_viz --verbosity=4" << std::endl;
-  ss << "    3. Running the visualizer with a configuration file: " << std::endl;
-  ss << "       $ maliput_viz --yaml_file_path=<path-to-yaml-file> " << std::endl << std::endl;
-  ss << " * YAML file configuration: " << std::endl;
-  ss << "    The --yaml_file_path flag expects a valid path to a YAML file." << std::endl;
-  ss << "    The YAML file should contain the configuration for loading the road network." << std::endl;
-  ss << "    The structure of the YAML file should be: " << std::endl;
-  ss << "     |  maliput_viz:" << std::endl;
-  ss << "     |    maliput_backend: <backend_name> " << std::endl;
-  ss << "     |    parameters: " << std::endl;
-  ss << "     |       <key_1>: <value_1> " << std::endl;
-  ss << "     |       <key_2>: <value_2> " << std::endl;
-  ss << "     |       ...  " << std::endl;
-  ss << "     |       <key_N>: <value_N> " << std::endl << std::endl;
+constexpr const char* kUsageMessage =
+    R"R(Application for maliput road network visualization.
 
-  return ss.str();
-}
+  Usage: maliput_viz [--<flag_1>] [--<flag_2>] .. [--<flag_n>]
+
+  * Summary:
+     This application offers a visualizer for the maliput road networks.
+     It provides a GUI for interactively select a maliput backend and load the road network
+     passing the correspondent parameters.
+     In addition, a YAML configuration file could be passed via command line for setting up the visualizer beforehand.
+
+  * Examples of use:
+     1. Running the visualizer:
+        $ maliput_viz
+     2. Running the visualizer with a higher verbosity level:
+        $ maliput_viz --verbosity=4
+     3. Running the visualizer with a configuration file:
+        $ maliput_viz --yaml_file_path=<path-to-yaml-file>
+
+  * YAML file configuration:
+     The --yaml_file_path flag expects a valid path to a YAML file.
+     The YAML file should contain the configuration for loading the road network.
+     The structure of the YAML file should be:
+      |  maliput_viz:
+      |    maliput_backend: <backend_name>
+      |    parameters:
+      |       <key_1>: <value_1>
+      |       <key_2>: <value_2>
+      |       ...
+      |       <key_N>: <value_N>
+)R";
 
 }  // namespace
 
@@ -102,7 +98,11 @@ void ParseCommandLineFlags(int argc, char** argv, bool remove_flags) {
   gflags::ParseCommandLineFlags(&argc, &argv, remove_flags);
 }
 
-void SetUsageMessage() { gflags::SetUsageMessage(GetUsageMessage()); }
+void SetUsageMessage() { gflags::SetUsageMessage(static_cast<std::string>(kUsageMessage)); }
+
+int GetVerbosity() { return FLAGS_verbosity; }
+
+std::string GetYamlFilePath() { return FLAGS_yaml_file_path; }
 
 }  // namespace flags
 }  // namespace viz

--- a/src/maliput_viz/flags/gflags.h
+++ b/src/maliput_viz/flags/gflags.h
@@ -29,18 +29,26 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
-#include <gflags/gflags.h>
-
-DECLARE_int32(verbosity);
-DECLARE_string(yaml_file_path);
+#include <string>
 
 namespace maliput {
 namespace viz {
 namespace flags {
 
+/// @brief Parses the command line flags.
+/// The gflags::ParseCommandLineFlags() function is called under the hood.
 void ParseCommandLineFlags(int argc, char** argv, bool remove_flags);
 
+/// @brief Sets the usage message.
+/// The gflags::SetUsageMessage() function is called under the hood with a defined message for the maliput_viz
+/// application.
 void SetUsageMessage();
+
+/// @returns Returns the value of the --verbosity flag.
+int GetVerbosity();
+
+/// @returns Returns the value of the --yaml_file_path flag.
+std::string GetYamlFilePath();
 
 }  // namespace flags
 }  // namespace viz

--- a/src/maliput_viz/flags/gflags.h
+++ b/src/maliput_viz/flags/gflags.h
@@ -1,0 +1,47 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2022, Woven Planet.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include <gflags/gflags.h>
+
+DECLARE_int32(verbosity);
+DECLARE_string(yaml_file_path);
+
+namespace maliput {
+namespace viz {
+namespace flags {
+
+void ParseCommandLineFlags(int argc, char** argv, bool remove_flags);
+
+void SetUsageMessage();
+
+}  // namespace flags
+}  // namespace viz
+}  // namespace maliput

--- a/src/maliput_viz/plugins/CMakeLists.txt
+++ b/src/maliput_viz/plugins/CMakeLists.txt
@@ -160,9 +160,11 @@ set_target_properties(MaliputViewerPlugin
 
 target_link_libraries(MaliputViewerPlugin
     maliput_viz::arrow_mesh
+    maliput_viz::flags
     maliput_viz::maliput_backend_selection
     maliput_viz::maliput_viewer_model
     maliput_viz::selector
+    maliput_viz::tools
     maliput_viz::traffic_light_manager
     ignition-gui3::ignition-gui3
     ignition-common3::ignition-common3

--- a/src/maliput_viz/plugins/maliput_backend_selection.cc
+++ b/src/maliput_viz/plugins/maliput_backend_selection.cc
@@ -170,5 +170,16 @@ void MaliputBackendSelection::OnLoadButtonPressed() {
       std::make_unique<MaliputViewerModel>(roadNetworkLoader->operator()(parameterTableModel->GetMapFromParameters()));
 }
 
+void MaliputBackendSelection::LoadBackendByDemand(const std::string& _backendName,
+                                                  const std::map<std::string, std::string>& _parameters) {
+  OnBackendSelected(QString::fromStdString(_backendName));
+  maliputViewerModel = std::make_unique<MaliputViewerModel>(roadNetworkLoader->operator()(_parameters));
+  parameterTableModel->ClearParameters();
+  for (const auto& parameter : _parameters) {
+    parameterTableModel->AddParameter(QString::fromStdString(parameter.first),
+                                      QString::fromStdString(parameter.second));
+  }
+}
+
 }  // namespace viz
 }  // namespace maliput

--- a/src/maliput_viz/plugins/maliput_backend_selection.hh
+++ b/src/maliput_viz/plugins/maliput_backend_selection.hh
@@ -106,6 +106,10 @@ class MaliputBackendSelection : public QObject {
   /// Returns a pointer to the MaliputViewerModel.
   MaliputViewerModel* GetMaliputModel() { return maliputViewerModel.get(); }
 
+  /// Load a backend with the given parameters. This is expected to be called by a parent class, skipping the use of the
+  /// gui.
+  void LoadBackendByDemand(const std::string& _backendName, const std::map<std::string, std::string>& _parameters);
+
  protected slots:
   /// Called when the user press the Load RoadNetwork button.
   void OnLoadButtonPressed();

--- a/src/maliput_viz/plugins/maliput_viewer_plugin.cc
+++ b/src/maliput_viz/plugins/maliput_viewer_plugin.cc
@@ -511,10 +511,10 @@ void MaliputViewerPlugin::timerEvent(QTimerEvent* _event) {
   timer.stop();
 
   // Verify if the visualizer should initiate a new road network from CLI.
-  if (FLAGS_yaml_file_path != "") {
-    tools::YamlConfigFileParser config_file_parser(FLAGS_yaml_file_path);
-    maliputBackendSelection.LoadBackendByDemand(config_file_parser.GetBackendName(),
-                                                config_file_parser.GetBackendParameters());
+  const std::string yaml_file_path = flags::GetYamlFilePath();
+  if (!yaml_file_path.empty()) {
+    const tools::MaliputVizConfig config{tools::LoadYamlConfigFile(yaml_file_path)};
+    maliputBackendSelection.LoadBackendByDemand(config.backend_name, config.backend_parameters);
     OnNewRoadNetwork();
   }
 }

--- a/src/maliput_viz/plugins/maliput_viewer_plugin.cc
+++ b/src/maliput_viz/plugins/maliput_viewer_plugin.cc
@@ -44,6 +44,9 @@
 #include <ignition/rendering/Visual.hh>
 #include <maliput/common/maliput_throw.h>
 
+#include "maliput_viz/flags/gflags.h"
+#include "maliput_viz/tools/yaml_parser.h"
+
 namespace maliput {
 namespace viz {
 namespace {
@@ -506,6 +509,14 @@ void MaliputViewerPlugin::timerEvent(QTimerEvent* _event) {
   setUpScene = true;
   ignmsg << "MaliputViewerPlugin has been initialized." << std::endl;
   timer.stop();
+
+  // Verify if the visualizer should initiate a new road network from CLI.
+  if (FLAGS_yaml_file_path != "") {
+    tools::YamlConfigFileParser config_file_parser(FLAGS_yaml_file_path);
+    maliputBackendSelection.LoadBackendByDemand(config_file_parser.GetBackendName(),
+                                                config_file_parser.GetBackendParameters());
+    OnNewRoadNetwork();
+  }
 }
 
 ignition::gui::Plugin* MaliputViewerPlugin::FilterPluginsByTitle(const std::string& _pluginTitle) {

--- a/src/maliput_viz/plugins/maliput_viewer_plugin.hh
+++ b/src/maliput_viz/plugins/maliput_viewer_plugin.hh
@@ -37,6 +37,7 @@
 #include <unordered_map>
 
 #include <QStandardItem>
+#include <gflags/gflags.h>
 #include <ignition/common/MouseEvent.hh>
 #include <ignition/gui/Plugin.hh>
 #include <ignition/rendering/RayQuery.hh>

--- a/src/maliput_viz/plugins/maliput_viewer_plugin.hh
+++ b/src/maliput_viz/plugins/maliput_viewer_plugin.hh
@@ -37,7 +37,6 @@
 #include <unordered_map>
 
 #include <QStandardItem>
-#include <gflags/gflags.h>
 #include <ignition/common/MouseEvent.hh>
 #include <ignition/gui/Plugin.hh>
 #include <ignition/rendering/RayQuery.hh>

--- a/src/maliput_viz/tools/CMakeLists.txt
+++ b/src/maliput_viz/tools/CMakeLists.txt
@@ -1,0 +1,27 @@
+add_library(tools
+  yaml_parser.cc
+)
+
+add_library(maliput_viz::tools ALIAS tools)
+set_target_properties(tools
+  PROPERTIES
+    OUTPUT_NAME tools
+)
+
+target_link_libraries(tools
+  maliput::common
+  yaml-cpp
+)
+
+target_include_directories(tools
+  PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
+)
+
+install(
+  TARGETS tools
+  EXPORT ${PROJECT_NAME}-targets
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+)

--- a/src/maliput_viz/tools/yaml_parser.cc
+++ b/src/maliput_viz/tools/yaml_parser.cc
@@ -1,0 +1,63 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2022, Woven Planet.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#include "maliput_viz/tools/yaml_parser.h"
+
+#include <maliput/common/maliput_throw.h>
+#include <yaml-cpp/yaml.h>
+
+namespace maliput {
+namespace viz {
+namespace tools {
+
+YamlConfigFileParser::YamlConfigFileParser(const std::string& file_path) {
+  YAML::Node root = YAML::LoadFile(file_path);
+  const auto maliput_viz_node = root[kMaliputVizKey];
+  MALIPUT_VALIDATE(maliput_viz_node.IsDefined(), "maliput_viz node not found in config file");
+  MALIPUT_VALIDATE(maliput_viz_node.IsMap(), "maliput_viz node is not a map");
+  const auto maliput_backend_node = maliput_viz_node[kMaliputBackendKey];
+  MALIPUT_VALIDATE(maliput_backend_node.IsDefined(), "maliput_backend node not found in config file");
+  backend_name_ = maliput_backend_node.as<std::string>();
+  const auto parameters_node = maliput_viz_node[kParametersKey];
+  if (parameters_node.IsDefined()) {
+    // Note that if it isn't defined then we just leave the parameters map empty.
+    MALIPUT_VALIDATE(parameters_node.IsMap(), "parameters node is not a map");
+  }
+  for (const auto& param : parameters_node) {
+    parameters_[param.first.as<std::string>()] = param.second.as<std::string>();
+  }
+}
+
+std::string YamlConfigFileParser::GetBackendName() const { return backend_name_; }
+
+std::map<std::string, std::string> YamlConfigFileParser::GetBackendParameters() const { return parameters_; }
+
+}  // namespace tools
+}  // namespace viz
+}  // namespace maliput

--- a/src/maliput_viz/tools/yaml_parser.cc
+++ b/src/maliput_viz/tools/yaml_parser.cc
@@ -36,27 +36,29 @@ namespace maliput {
 namespace viz {
 namespace tools {
 
-YamlConfigFileParser::YamlConfigFileParser(const std::string& file_path) {
+MaliputVizConfig LoadYamlConfigFile(const std::string& file_path) {
+  static constexpr char kMaliputVizKey[] = "maliput_viz";
+  static constexpr char kMaliputBackendKey[] = "maliput_backend";
+  static constexpr char kParametersKey[] = "parameters";
   YAML::Node root = YAML::LoadFile(file_path);
   const auto maliput_viz_node = root[kMaliputVizKey];
   MALIPUT_VALIDATE(maliput_viz_node.IsDefined(), "maliput_viz node not found in config file");
   MALIPUT_VALIDATE(maliput_viz_node.IsMap(), "maliput_viz node is not a map");
   const auto maliput_backend_node = maliput_viz_node[kMaliputBackendKey];
   MALIPUT_VALIDATE(maliput_backend_node.IsDefined(), "maliput_backend node not found in config file");
-  backend_name_ = maliput_backend_node.as<std::string>();
+
+  MaliputVizConfig config{};
+  config.backend_name = maliput_backend_node.as<std::string>();
   const auto parameters_node = maliput_viz_node[kParametersKey];
   if (parameters_node.IsDefined()) {
     // Note that if it isn't defined then we just leave the parameters map empty.
     MALIPUT_VALIDATE(parameters_node.IsMap(), "parameters node is not a map");
   }
   for (const auto& param : parameters_node) {
-    parameters_[param.first.as<std::string>()] = param.second.as<std::string>();
+    config.backend_parameters[param.first.as<std::string>()] = param.second.as<std::string>();
   }
+  return config;
 }
-
-std::string YamlConfigFileParser::GetBackendName() const { return backend_name_; }
-
-std::map<std::string, std::string> YamlConfigFileParser::GetBackendParameters() const { return parameters_; }
 
 }  // namespace tools
 }  // namespace viz

--- a/src/maliput_viz/tools/yaml_parser.h
+++ b/src/maliput_viz/tools/yaml_parser.h
@@ -37,7 +37,15 @@ namespace maliput {
 namespace viz {
 namespace tools {
 
-/// Parser for a YAML file to be used by the maliput_viz application.
+/// Holds the configuration parameters loaded from a YAML file.
+struct MaliputVizConfig {
+  /// The name of the backend to be used.
+  std::string backend_name{};
+  /// The parameters to be passed to the backend's loader.
+  std::map<std::string, std::string> backend_parameters{};
+};
+
+/// Parses a YAML file to be used by the maliput_viz application.
 /// The YAML file must have the following structure:
 /// @code {.yaml}
 /// maliput_viz:"
@@ -48,25 +56,7 @@ namespace tools {
 ///      // ...
 ///      <key_N>: <value_N> "
 /// @endcode
-class YamlConfigFileParser {
- public:
-  /// @brief  Constructor
-  /// @param file_path Path to a YAML file.
-  YamlConfigFileParser(const std::string& file_path);
-  ~YamlConfigFileParser() = default;
-
-  /// @returns The parsed backend name.
-  std::string GetBackendName() const;
-  /// @returns The parsed parameters
-  std::map<std::string, std::string> GetBackendParameters() const;
-
- private:
-  static constexpr char kMaliputVizKey[] = "maliput_viz";
-  static constexpr char kMaliputBackendKey[] = "maliput_backend";
-  static constexpr char kParametersKey[] = "parameters";
-  std::string backend_name_;
-  std::map<std::string, std::string> parameters_;
-};
+MaliputVizConfig LoadYamlConfigFile(const std::string& file_path);
 
 }  // namespace tools
 }  // namespace viz

--- a/src/maliput_viz/tools/yaml_parser.h
+++ b/src/maliput_viz/tools/yaml_parser.h
@@ -1,0 +1,73 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2022, Woven Planet.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <map>
+#include <string>
+
+namespace maliput {
+namespace viz {
+namespace tools {
+
+/// Parser for a YAML file to be used by the maliput_viz application.
+/// The YAML file must have the following structure:
+/// @code {.yaml}
+/// maliput_viz:"
+///   maliput_backend: <backend_name> "
+///   parameters: "
+///      <key_1>: <value_1> "
+///      <key_2>: <value_2> "
+///      // ...
+///      <key_N>: <value_N> "
+/// @endcode
+class YamlConfigFileParser {
+ public:
+  /// @brief  Constructor
+  /// @param file_path Path to a YAML file.
+  YamlConfigFileParser(const std::string& file_path);
+  ~YamlConfigFileParser() = default;
+
+  /// @returns The parsed backend name.
+  std::string GetBackendName() const;
+  /// @returns The parsed parameters
+  std::map<std::string, std::string> GetBackendParameters() const;
+
+ private:
+  static constexpr char kMaliputVizKey[] = "maliput_viz";
+  static constexpr char kMaliputBackendKey[] = "maliput_backend";
+  static constexpr char kParametersKey[] = "parameters";
+  std::string backend_name_;
+  std::map<std::string, std::string> parameters_;
+};
+
+}  // namespace tools
+}  // namespace viz
+}  // namespace maliput


### PR DESCRIPTION
# 🎉 New feature

Related to #15 

## Summary
Add CLI support for maliput_viz configuration.

The `maliput_viz` application supports passing a yaml file with the configuration to load a road network with a given backend.
The yaml file is expected to contain information about the maliput backend to use and the parameters to be passed to the selected backend.


https://user-images.githubusercontent.com/53065142/206535975-21401dbb-e73b-4c8d-b7ed-22d4c64a28d7.mp4

## Test it
Try:
```
maliput_viz --help
```
Create a yaml file with:
```yaml
---
maliput_viz:
  maliput_backend: "maliput_dragway"
  parameters:
    num_lanes: 16
    length: 1789
    lane_width: 3
    shoulder_width: 1
```
And then run
```
maliput_viz --yaml_file_path=<path-to-yaml-file>
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
