### PR TITLE
Support visualization of TrafficSigns in the RoadNetwork.

### DIFF
--- a/src/maliput_viz/plugins/CMakeLists.txt
+++ b/src/maliput_viz/plugins/CMakeLists.txt
@@ -108,6 +108,32 @@ install(
   ARCHIVE DESTINATION lib
 )
 
+# ----------------------------------------
+# traffic_sign_manager library.
+add_library(traffic_sign_manager
+  traffic_sign_manager.cc
+)
+add_library(maliput_viz::traffic_sign_manager ALIAS traffic_sign_manager)
+set_target_properties(traffic_sign_manager
+  PROPERTIES
+    OUTPUT_NAME maliput_viz_traffic_sign_manager
+)
+
+target_link_libraries(traffic_sign_manager
+  ignition-common3::ignition-common3
+  ignition-math6::ignition-math6
+  ignition-rendering3::ignition-rendering3
+  maliput::api
+)
+
+install(
+  TARGETS traffic_sign_manager
+  EXPORT ${PROJECT_NAME}-targets
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+)
+
 #-------------------------------------------------------------------------------
 # maliput_backend_selection (Qt Object)
 QT5_WRAP_CPP(maliput_backend_selection_headers_MOC maliput_backend_selection.hh)
@@ -166,6 +192,7 @@ target_link_libraries(MaliputViewerPlugin
     maliput_viz::selector
     maliput_viz::tools
     maliput_viz::traffic_light_manager
+    maliput_viz::traffic_sign_manager
     ignition-gui3::ignition-gui3
     ignition-common3::ignition-common3
     ignition-transport8::ignition-transport8

--- a/src/maliput_viz/plugins/MaliputViewerPlugin.qml
+++ b/src/maliput_viz/plugins/MaliputViewerPlugin.qml
@@ -161,4 +161,23 @@ Rectangle {
     anchors.left: parent.left
     anchors.right: parent.right
   }
+  // Traffic Sign Info Panel
+  Loader {
+    id: signInfoLoader
+    width: parent.width
+    source: "SignInfoArea.qml"
+    anchors.top: rulesListLoader.bottom
+    anchors.left: parent.left
+    anchors.right: parent.right
+  }
+  ToolSeparator {
+    id: signInfoSeparator
+    orientation: Qt.Horizontal
+    anchors.top: signInfoLoader.bottom
+    anchors.topMargin: 15
+    anchors.left: parent.left
+    anchors.leftMargin: 10
+    anchors.right: parent.right
+    anchors.rightMargin: 10
+  }
 }

--- a/src/maliput_viz/plugins/SignInfoArea.qml
+++ b/src/maliput_viz/plugins/SignInfoArea.qml
@@ -1,0 +1,76 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2022, Woven Planet. All rights reserved.
+// Copyright (c) 2021-2022, Toyota Research Institute. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import QtQuick 2.9
+import QtQuick.Controls 1.4
+import QtQuick.Controls.Material 2.1
+import QtQuick.Layouts 1.3
+
+GridLayout {
+  id: signInfoPanel
+  columns: 1
+  anchors.left: parent.left
+  anchors.leftMargin: 10
+  anchors.right: parent.right
+  anchors.rightMargin: 10
+  anchors.top: parent.top
+  Layout.fillWidth: true
+
+  // Title text.
+  Text {
+    id: titleText
+    Layout.columnSpan: 1
+    Layout.alignment: Qt.AlignVTop | Qt.AlignHCenter
+    font.family: "Helvetica"
+    font.pixelSize: 14
+    text: "SIGN INFO"
+  }
+
+  // Text area used to show fields of the clicked traffic sign.
+  TextArea {
+    id: signInfo
+    width: parent.width
+    Layout.alignment: Qt.AlignVTop | Qt.AlignHLeft
+    Layout.minimumHeight: 100
+    Layout.preferredHeight: 140
+    Layout.maximumHeight: 150
+    Layout.fillWidth: true
+    font.pixelSize: 12
+    font.family: "Helvetica"
+  }
+
+  // When new data arrives the text area is updated.
+  Connections {
+    target: MaliputViewerPlugin
+    onSignInfoChanged: {
+      signInfo.text = MaliputViewerPlugin.signInfo
+    }
+  }
+}

--- a/src/maliput_viz/plugins/maliput_viewer_model.cc
+++ b/src/maliput_viz/plugins/maliput_viewer_model.cc
@@ -592,6 +592,12 @@ std::vector<const maliput::api::rules::TrafficLight*> MaliputViewerModel::GetTra
 }
 
 ///////////////////////////////////////////////////////
+std::vector<const maliput::api::rules::TrafficSign*> MaliputViewerModel::GetTrafficSigns() const {
+  return this->roadNetwork != nullptr ? this->roadNetwork->traffic_sign_book()->TrafficSigns()
+                                      : std::vector<const maliput::api::rules::TrafficSign*>();
+}
+
+///////////////////////////////////////////////////////
 maliput::api::rules::BulbStates MaliputViewerModel::GetBulbStates(const std::string& _phaseRingId,
                                                                   const std::string& _phaseId) const {
   if (this->roadNetwork && !_phaseRingId.empty() && !_phaseId.empty()) {

--- a/src/maliput_viz/plugins/maliput_viewer_model.hh
+++ b/src/maliput_viz/plugins/maliput_viewer_model.hh
@@ -245,6 +245,10 @@ class MaliputViewerModel {
   /// \returns Vector containing all the traffic lights that the underlying road network contains.
   std::vector<const maliput::api::rules::TrafficLight*> GetTrafficLights() const;
 
+  /// \brief Get all the traffic signs from the underlying traffic sign book that lives in the road network if any.
+  /// \returns Vector containing all the traffic signs that the underlying road network contains.
+  std::vector<const maliput::api::rules::TrafficSign*> GetTrafficSigns() const;
+
   /// \brief Get N lanes from the underlying road geometry.
   /// \param[in] _n Amount of lanes desired to get from the underlying
   /// road geometry.

--- a/src/maliput_viz/plugins/maliput_viewer_plugin.cc
+++ b/src/maliput_viz/plugins/maliput_viewer_plugin.cc
@@ -30,6 +30,7 @@
 #include "maliput_viewer_plugin.hh"
 
 #include <algorithm>
+#include <sstream>
 #include <vector>
 
 #include <ignition/common/Console.hh>
@@ -138,6 +139,8 @@ QStringList MaliputViewerPlugin::ListLanes() const { return listLanes; }
 QString MaliputViewerPlugin::RulesList() const { return rulesList; }
 
 QString MaliputViewerPlugin::LaneInfo() const { return laneInfo; }
+
+QString MaliputViewerPlugin::SignInfo() const { return signInfo; }
 
 QList<bool> MaliputViewerPlugin::LayerCheckboxes() const {
   // Returns the checkboxes' state by default.
@@ -417,6 +420,8 @@ void MaliputViewerPlugin::Clear() {
     phaseTreeModel.Clear();
     // Resert traffic light manager.
     trafficLightManager->Clear();
+    // Clear traffic sign manager.
+    trafficSignManager->Clear();
     isRoadNetworkLoaded = false;
   }
   newRoadNetwork = false;
@@ -554,6 +559,8 @@ void MaliputViewerPlugin::SetUpScene() {
                                         selMinTolerance);
   // Create traffic light manager.
   trafficLightManager = std::make_unique<TrafficLightManager>(this->scene);
+  // Create traffic sign manager.
+  trafficSignManager = std::make_unique<TrafficSignManager>(this->scene);
 }
 
 bool MaliputViewerPlugin::eventFilter(QObject* _obj, QEvent* _event) {
@@ -577,6 +584,7 @@ bool MaliputViewerPlugin::eventFilter(QObject* _obj, QEvent* _event) {
         this->RenderRoadMeshes(maliputBackendSelection.GetMaliputModel()->Meshes());
         this->RenderLabels(maliputBackendSelection.GetMaliputModel()->Labels());
         this->trafficLightManager->CreateTrafficLights(maliputBackendSelection.GetMaliputModel()->GetTrafficLights());
+        this->trafficSignManager->CreateTrafficSigns(maliputBackendSelection.GetMaliputModel()->GetTrafficSigns());
         this->renderMeshesOption.executeLabelRendering = false;
         this->renderMeshesOption.executeMeshRendering = false;
         this->newRoadNetwork = false;
@@ -616,6 +624,11 @@ void MaliputViewerPlugin::MouseClickHandler(const ignition::math::Vector3d& _sce
                                 ? RoadPositionResultValue()
                                 : RoadPositionResultValue(newRoadPositionResult, _distance);
   roadPositionResultValue.SetDirty(true);
+
+  // Check if a traffic sign was clicked and update the sign info panel accordingly.
+  const maliput::api::rules::TrafficSign* clicked_sign =
+      trafficSignManager->GetTrafficSignAtPoint(_sceneInertialPosition, /*tolerance=*/0.5);
+  UpdateSignInfoArea(clicked_sign);
 }
 
 void MaliputViewerPlugin::UpdateLaneSelectionOnLeftClick() {
@@ -692,6 +705,40 @@ void MaliputViewerPlugin::UpdateLaneInfoArea(const maliput::api::RoadPositionRes
 
   laneInfo = QString::fromStdString(ss.str());
   emit LaneInfoChanged();
+}
+
+void MaliputViewerPlugin::UpdateSignInfoArea(const maliput::api::rules::TrafficSign* _sign) {
+  if (_sign == nullptr) {
+    signInfo = QString{};
+    emit SignInfoChanged();
+    return;
+  }
+
+  const auto type_map = maliput::api::rules::TrafficSignTypeMapper();
+  const std::string type_str =
+      type_map.count(_sign->type()) ? std::string(type_map.at(_sign->type())) : "unknown";
+
+  const maliput::api::InertialPosition& pos = _sign->position_road_network();
+  const maliput::api::Rotation& rot = _sign->orientation_road_network();
+  const maliput::math::BoundingBox& bb = _sign->bounding_box();
+
+  std::stringstream ss;
+  ss << "---- TRAFFIC SIGN: " << _sign->id().string() << " ----";
+  ss << "\nType:         " << type_str;
+  ss << "\nMessage:      " << (_sign->message().has_value() ? _sign->message().value() : "(none)");
+  ss << "\nPosition:     (x=" << pos.x() << ", y=" << pos.y() << ", z=" << pos.z() << ")";
+  ss << "\nOrientation:  (roll=" << rot.roll() << ", pitch=" << rot.pitch() << ", yaw=" << rot.yaw() << ")";
+  ss << "\nRelated Lanes: [";
+  for (const auto& lane_id : _sign->related_lanes()) {
+    ss << lane_id.string() << " ";
+  }
+  ss << "]";
+  ss << "\nBoundingBox:"
+     << " center=(" << bb.position().x() << ", " << bb.position().y() << ", " << bb.position().z() << ")"
+     << " size=(" << bb.box_size().x() << ", " << bb.box_size().y() << ", " << bb.box_size().z() << ")";
+
+  signInfo = QString::fromStdString(ss.str());
+  emit SignInfoChanged();
 }
 
 void MaliputViewerPlugin::UpdateLane(const std::string& _id) {

--- a/src/maliput_viz/plugins/maliput_viewer_plugin.cc
+++ b/src/maliput_viz/plugins/maliput_viewer_plugin.cc
@@ -715,8 +715,7 @@ void MaliputViewerPlugin::UpdateSignInfoArea(const maliput::api::rules::TrafficS
   }
 
   const auto type_map = maliput::api::rules::TrafficSignTypeMapper();
-  const std::string type_str =
-      type_map.count(_sign->type()) ? std::string(type_map.at(_sign->type())) : "unknown";
+  const std::string type_str = type_map.count(_sign->type()) ? std::string(type_map.at(_sign->type())) : "unknown";
 
   const maliput::api::InertialPosition& pos = _sign->position_road_network();
   const maliput::api::Rotation& rot = _sign->orientation_road_network();

--- a/src/maliput_viz/plugins/maliput_viewer_plugin.hh
+++ b/src/maliput_viz/plugins/maliput_viewer_plugin.hh
@@ -49,6 +49,7 @@
 #include "maliput_backend_selection.hh"
 #include "selector.hh"
 #include "traffic_light_manager.hh"
+#include "traffic_sign_manager.hh"
 
 namespace maliput {
 namespace viz {
@@ -127,6 +128,9 @@ class MaliputViewerPlugin : public ignition::gui::Plugin {
   /// Property used to load the info about the surface clicked in the correspondant UI's area.
   Q_PROPERTY(QString laneInfo READ LaneInfo NOTIFY LaneInfoChanged)
 
+  /// Property used to display the fields of the traffic sign clicked in the correspondant UI's area.
+  Q_PROPERTY(QString signInfo READ SignInfo NOTIFY SignInfoChanged)
+
  public:
   /// \brief Default constructor.
   MaliputViewerPlugin();
@@ -143,6 +147,9 @@ class MaliputViewerPlugin : public ignition::gui::Plugin {
 
   /// Called when a lane is clicked. Update info related to the clicked surface.
   Q_INVOKABLE QString LaneInfo() const;
+
+  /// Called when a traffic sign is clicked. Returns the sign's fields as a formatted string.
+  Q_INVOKABLE QString SignInfo() const;
 
   /// Called when a new RoadNetwork is loaded to default the checkboxes' state
   /// in the layers selection panel for the meshes.
@@ -161,6 +168,9 @@ class MaliputViewerPlugin : public ignition::gui::Plugin {
 
   /// \brief Signal emitted to update the info about the clicked lane.
   void LaneInfoChanged();
+
+  /// \brief Signal emitted to update the info about the clicked traffic sign.
+  void SignInfoChanged();
 
   /// \brief Signal emitted to reset the checkboxes' state for the layers visualization
   ///        when a new RoadNetwork is loaded.
@@ -340,6 +350,10 @@ class MaliputViewerPlugin : public ignition::gui::Plugin {
   /// \param[in] _roadPositionResult Result of the mapped RoadPosition after a click in the scene.
   void UpdateLaneInfoArea(const maliput::api::RoadPositionResult& _roadPositionResult);
 
+  /// \brief Updates the sign info area with the fields of the given traffic sign.
+  /// \param[in] _sign Pointer to the clicked traffic sign. May be nullptr to clear the area.
+  void UpdateSignInfoArea(const maliput::api::rules::TrafficSign* _sign);
+
   /// Keys used by the checkbox logic to visualize different layers and by
   /// the default map #objectVisualDefaults.
   /// @{
@@ -391,6 +405,9 @@ class MaliputViewerPlugin : public ignition::gui::Plugin {
   /// \brief Holds the info about the clicked surface that is displayed in the UI.
   QString laneInfo{};
 
+  /// \brief Holds the fields of the last clicked traffic sign displayed in the UI.
+  QString signInfo{};
+
   /// @brief Triggers an event every `kTimerPeriodInMs` to try to get the scene.
   QBasicTimer timer;
 
@@ -429,6 +446,9 @@ class MaliputViewerPlugin : public ignition::gui::Plugin {
 
   /// \brief Manager of traffic lights visualization.
   std::unique_ptr<TrafficLightManager> trafficLightManager;
+
+  /// \brief Manager of traffic signs visualization.
+  std::unique_ptr<TrafficSignManager> trafficSignManager;
 
   /// \brief Holds the RoadPositionResult upon a left click in the scene.
   RoadPositionResultValue roadPositionResultValue;

--- a/src/maliput_viz/plugins/maliput_viewer_plugin.qrc
+++ b/src/maliput_viz/plugins/maliput_viewer_plugin.qrc
@@ -8,5 +8,6 @@
     <file>RulesListArea.qml</file>
     <file>PhaseSelectionArea.qml</file>
     <file>InfoArea.qml</file>
+    <file>SignInfoArea.qml</file>
   </qresource>
 </RCC>

--- a/src/maliput_viz/plugins/traffic_sign_manager.cc
+++ b/src/maliput_viz/plugins/traffic_sign_manager.cc
@@ -51,8 +51,7 @@ TrafficSignManager::TrafficSignManager(ignition::rendering::ScenePtr _scene) : s
   signMaterial->SetTransparency(0.5);
 }
 
-void TrafficSignManager::CreateTrafficSigns(
-    const std::vector<const maliput::api::rules::TrafficSign*>& _signs) {
+void TrafficSignManager::CreateTrafficSigns(const std::vector<const maliput::api::rules::TrafficSign*>& _signs) {
   signs_.reserve(_signs.size());
   for (const maliput::api::rules::TrafficSign* sign : _signs) {
     CreateSingleTrafficSign(sign);
@@ -98,8 +97,7 @@ void TrafficSignManager::CreateSingleTrafficSign(const maliput::api::rules::Traf
       ign_q * ignition::math::Vector3d(bb_local_pos.x(), bb_local_pos.y(), bb_local_pos.z());
 
   const maliput::math::Vector3& size = bb.box_size();
-  const double half_diagonal =
-      0.5 * std::sqrt(size.x() * size.x() + size.y() * size.y() + size.z() * size.z());
+  const double half_diagonal = 0.5 * std::sqrt(size.x() * size.x() + size.y() * size.y() + size.z() * size.z());
 
   ignition::rendering::VisualPtr visual = scene->CreateVisual();
   if (!visual) {

--- a/src/maliput_viz/plugins/traffic_sign_manager.cc
+++ b/src/maliput_viz/plugins/traffic_sign_manager.cc
@@ -1,0 +1,120 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2022, Woven Planet. All rights reserved.
+// Copyright (c) 2019-2022, Toyota Research Institute. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#include "traffic_sign_manager.hh"
+
+#include <cmath>
+#include <limits>
+
+#include <ignition/common/Console.hh>
+#include <ignition/math/Quaternion.hh>
+#include <maliput/common/maliput_throw.h>
+
+namespace maliput {
+namespace viz {
+
+const std::string TrafficSignManager::kSignMaterialName{"TrafficSignBox"};
+
+TrafficSignManager::TrafficSignManager(ignition::rendering::ScenePtr _scene) : scene(_scene) {
+  MALIPUT_THROW_UNLESS(scene != nullptr);
+  signMaterial = scene->CreateMaterial(kSignMaterialName);
+  MALIPUT_THROW_UNLESS(signMaterial != nullptr);
+  // Cyan-ish color with transparency so the bounding box is distinguishable but not occluding.
+  signMaterial->SetDiffuse(0.0, 200.0, 200.0, 1.0);
+  signMaterial->SetAmbient(0.0, 200.0, 200.0, 1.0);
+  signMaterial->SetTransparency(0.5);
+}
+
+void TrafficSignManager::CreateTrafficSigns(
+    const std::vector<const maliput::api::rules::TrafficSign*>& _signs) {
+  signs_.reserve(_signs.size());
+  for (const maliput::api::rules::TrafficSign* sign : _signs) {
+    CreateSingleTrafficSign(sign);
+  }
+}
+
+void TrafficSignManager::Clear() {
+  for (const auto& entry : signs_) {
+    scene->RootVisual()->RemoveChild(entry.second.visual);
+  }
+  signs_.clear();
+}
+
+const maliput::api::rules::TrafficSign* TrafficSignManager::GetTrafficSignAtPoint(
+    const ignition::math::Vector3d& _point, double _tolerance) const {
+  const maliput::api::rules::TrafficSign* closest{nullptr};
+  double closestDist{std::numeric_limits<double>::max()};
+
+  for (const auto& entry : signs_) {
+    const double dist = (entry.second.worldCenter - _point).Length();
+    if (dist <= entry.second.boundingSphereRadius + _tolerance && dist < closestDist) {
+      closestDist = dist;
+      closest = entry.second.sign;
+    }
+  }
+  return closest;
+}
+
+void TrafficSignManager::CreateSingleTrafficSign(const maliput::api::rules::TrafficSign* _sign) {
+  MALIPUT_THROW_UNLESS(_sign != nullptr);
+
+  const maliput::api::InertialPosition& world_pos = _sign->position_road_network();
+  const maliput::api::Rotation& world_rot = _sign->orientation_road_network();
+  const maliput::math::BoundingBox& bb = _sign->bounding_box();
+
+  // The bounding box position is expressed in the sign's local frame.
+  // Rotate it to world frame using the sign's orientation quaternion.
+  const auto& maliput_q = world_rot.quat();
+  const ignition::math::Quaterniond ign_q(maliput_q.w(), maliput_q.x(), maliput_q.y(), maliput_q.z());
+  const maliput::math::Vector3& bb_local_pos = bb.position();
+  const ignition::math::Vector3d world_center =
+      ignition::math::Vector3d(world_pos.x(), world_pos.y(), world_pos.z()) +
+      ign_q * ignition::math::Vector3d(bb_local_pos.x(), bb_local_pos.y(), bb_local_pos.z());
+
+  const maliput::math::Vector3& size = bb.box_size();
+  const double half_diagonal =
+      0.5 * std::sqrt(size.x() * size.x() + size.y() * size.y() + size.z() * size.z());
+
+  ignition::rendering::VisualPtr visual = scene->CreateVisual();
+  if (!visual) {
+    ignerr << "TrafficSignManager: failed to create visual for sign " << _sign->id().string() << std::endl;
+    return;
+  }
+  visual->AddGeometry(scene->CreateBox());
+  visual->SetWorldScale(size.x(), size.y(), size.z());
+  visual->SetWorldRotation(world_rot.roll(), world_rot.pitch(), world_rot.yaw());
+  visual->SetWorldPosition(world_center);
+  visual->SetMaterial(signMaterial, false);
+  scene->RootVisual()->AddChild(visual);
+
+  signs_[_sign->id()] = SignVisual{visual, world_center, half_diagonal, _sign};
+}
+
+}  // namespace viz
+}  // namespace maliput

--- a/src/maliput_viz/plugins/traffic_sign_manager.hh
+++ b/src/maliput_viz/plugins/traffic_sign_manager.hh
@@ -1,0 +1,98 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2022, Woven Planet. All rights reserved.
+// Copyright (c) 2019-2022, Toyota Research Institute. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <ignition/math/Vector3.hh>
+#include <ignition/rendering/Scene.hh>
+#include <maliput/api/rules/traffic_sign.h>
+
+namespace maliput {
+namespace viz {
+
+/// \brief Class that creates and owns rendering visuals for traffic signs.
+///
+/// Each sign is represented as a single colored box matching the sign's bounding box.
+/// The manager also supports proximity-based hit testing so that a scene click can be
+/// resolved to the nearest traffic sign.
+class TrafficSignManager final {
+ public:
+  explicit TrafficSignManager(ignition::rendering::ScenePtr _scene);
+  /// \brief Destructor. Visual destruction is handled by the scene.
+  ~TrafficSignManager() = default;
+
+  /// \brief Creates rendering visuals for all provided traffic signs.
+  /// \param[in] _signs Vector of traffic sign pointers to visualize.
+  void CreateTrafficSigns(const std::vector<const maliput::api::rules::TrafficSign*>& _signs);
+
+  /// \brief Removes and destroys all visuals owned by this manager.
+  void Clear();
+
+  /// \brief Returns the traffic sign closest to @p _point whose bounding sphere
+  ///        contains @p _point (within @p _tolerance), or nullptr if none match.
+  /// \param[in] _point World-space position to test.
+  /// \param[in] _tolerance Extra distance added to each sign's bounding sphere radius.
+  /// \returns Pointer to the matching TrafficSign, or nullptr.
+  const maliput::api::rules::TrafficSign* GetTrafficSignAtPoint(const ignition::math::Vector3d& _point,
+                                                                double _tolerance = 0.0) const;
+
+ private:
+  /// \brief Material name used for all sign visuals.
+  static const std::string kSignMaterialName;
+
+  /// \brief Holds per-sign rendering data used for hit testing.
+  struct SignVisual {
+    /// Ignition rendering visual for the bounding box.
+    ignition::rendering::VisualPtr visual;
+    /// World-space centroid of the sign's bounding box.
+    ignition::math::Vector3d worldCenter;
+    /// Half-diagonal of the bounding box used for bounding-sphere hit tests.
+    double boundingSphereRadius{0.0};
+    /// Non-owning pointer back to the source sign (owned by the TrafficSignBook).
+    const maliput::api::rules::TrafficSign* sign{nullptr};
+  };
+
+  /// \brief Creates a single sign visual and registers it.
+  /// \param[in] _sign Non-null pointer to a TrafficSign.
+  void CreateSingleTrafficSign(const maliput::api::rules::TrafficSign* _sign);
+
+  /// \brief Pointer to the ignition rendering scene.
+  ignition::rendering::ScenePtr scene;
+  /// \brief Shared material applied to every sign visual.
+  ignition::rendering::MaterialPtr signMaterial;
+  /// \brief Map from TrafficSign::Id to its rendering data.
+  std::unordered_map<maliput::api::rules::TrafficSign::Id, SignVisual> signs_;
+};
+
+}  // namespace viz
+}  // namespace maliput


### PR DESCRIPTION
# 🎉 New feature

## Summary
* TrafficSign's bounding boxes are added to the visualizer.

## Test it
```bash
colcon build --packages-select maliput maliput_malidrive maliput_viz
. install/setup.bash
maliput_viz --yaml_file_path=src/maliput_malidrive/resources/TwoRoadsWithTrafficSigns_viz.yaml
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Added example and/or tutorial
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
